### PR TITLE
Add native share button with fallback and styles to post pages

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -28,6 +28,7 @@ window.addEventListener("load", function () {
   }
 });
 `
+const shareText = `${post.data.title} | ochisamu.info`
 ---
 
 <Base
@@ -63,6 +64,30 @@ window.addEventListener("load", function () {
       itemprop="articleBody"
     >
       <Content />
+    </section>
+    <section class="mt-4 rounded-2xl bg-white p-4 shadow-2xl shadow-slate-950/10 ring-1 ring-slate-200 sm:mt-5 sm:rounded-3xl sm:p-5">
+      <div class="share-toolbar">
+        <h2 class="m-0 text-base font-black text-slate-950">この記事を共有</h2>
+        <button
+          type="button"
+          class="share-button"
+          data-share-native
+          data-share-title={post.data.title}
+          data-share-text={shareText}
+        >
+          共有する
+        </button>
+      </div>
+      <p class="share-status" data-share-status role="status" aria-live="polite"></p>
+      <div class="share-fallback-links" data-share-fallback hidden>
+        <a
+          href={`https://x.com/intent/tweet?text=${encodeURIComponent(shareText)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          X で共有
+        </a>
+      </div>
     </section>
   </article>
   <footer class="mx-auto mt-12 max-w-3xl sm:mt-16">
@@ -104,4 +129,43 @@ window.addEventListener("load", function () {
       </>
     )
   }
+  <script is:inline>
+    (() => {
+      const button = document.querySelector("[data-share-native]");
+      const status = document.querySelector("[data-share-status]");
+      const fallback = document.querySelector("[data-share-fallback]");
+      if (!button || !status || !fallback) return;
+
+      if (!("share" in navigator)) {
+        fallback.removeAttribute("hidden");
+      }
+
+      button.addEventListener("click", async () => {
+        const url = window.location.href;
+        const title = button.getAttribute("data-share-title") || document.title;
+        const text = button.getAttribute("data-share-text") || title;
+        status.textContent = "";
+
+        try {
+          if (navigator.share) {
+            await navigator.share({ title, text, url });
+            return;
+          }
+
+          if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(url);
+            status.textContent = "リンクをコピーしました。";
+            fallback.removeAttribute("hidden");
+            return;
+          }
+
+          fallback.removeAttribute("hidden");
+          status.textContent = "共有機能が使えないため、リンクから共有してください。";
+        } catch (_error) {
+          fallback.removeAttribute("hidden");
+          status.textContent = "共有できなかったため、リンクから共有してください。";
+        }
+      });
+    })();
+  </script>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -176,4 +176,25 @@
   nav.mx-auto li:last-child a[rel] {
     @apply justify-end text-right sm:justify-end;
   }
+
+  .share-toolbar {
+    @apply flex flex-wrap items-center justify-between gap-3;
+  }
+
+  .share-button {
+    @apply inline-flex min-h-11 items-center rounded-full border border-slate-200 bg-white px-4 text-sm font-black text-slate-700 no-underline shadow-sm transition hover:border-rose-200 hover:text-rose-700 hover:shadow-lg;
+  }
+
+  .share-status {
+    @apply mt-2 mb-0 text-sm font-bold text-slate-600;
+    min-height: 1.5rem;
+  }
+
+  .share-fallback-links {
+    @apply mt-1 flex flex-wrap gap-3;
+  }
+
+  .share-fallback-links a {
+    @apply text-sm font-black;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide an easy way for readers to share articles using the platform-native share sheet when available and a fallback when not.
- Surface a quick-copy and X (Twitter/X) sharing link for environments without `navigator.share` support.
- Keep the share UI visually consistent with existing post actions and site styling.

### Description
- Added a `shareText` constant and a new share section to `src/pages/[...slug].astro` containing a `button` with `data-share-native`, a `role=status` element for messages, and a hidden fallback area with an X share link using `encodeURIComponent(shareText)`.
- Implemented inline client-side logic in the same file to handle `navigator.share`, `navigator.clipboard.writeText`, and show or reveal fallback UI and status messages on errors or unsupported environments.
- Introduced stylesheet rules in `src/styles/global.css` for `.share-toolbar`, `.share-button`, `.share-status`, and `.share-fallback-links` to match the site’s existing visual patterns.
- Kept existing mermaid handling and navigation unchanged.

### Testing
- No automated tests were added or executed as part of this change.
- The change is limited to UI, inline script, and CSS and is expected to be covered by the repository's existing CI pipeline (build/lint/tests) when the PR is merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f992cf23a083258183268f95482ae8)